### PR TITLE
feat(css-prop): adds support for objects in template literals

### DIFF
--- a/src/ts-transformer/css-prop/__tests__/index.test.tsx
+++ b/src/ts-transformer/css-prop/__tests__/index.test.tsx
@@ -86,11 +86,11 @@ describe('css prop transformer', () => {
 
     it('should transform template string literal with string variable', () => {
       const actual = transform(`
-          /** @jsx jsx */
-          import { jsx } from '${pkg.name}';
+        /** @jsx jsx */
+        import { jsx } from '${pkg.name}';
 
-          const color = 'blue';
-          <div css={\`color: \${color};\`}>hello world</div>
+        const color = 'blue';
+        <div css={\`color: \${color};\`}>hello world</div>
       `);
 
       expect(actual).toInclude('<style>.test-class{color:var(--color-test-css-variable);}</style>');
@@ -101,7 +101,17 @@ describe('css prop transformer', () => {
 
     it.todo('should transform template string literal with string import');
 
-    it.todo('should transform template string literal with obj variable');
+    it('should transform template string literal with obj variable', () => {
+      const actual = transform(`
+        /** @jsx jsx */
+        import { jsx } from '${pkg.name}';
+
+        const style = { color: 'blue', fontSize: '30px' };
+        <div css={\`\${style}\`}>hello world</div>
+      `);
+
+      expect(actual).toInclude('<style>.test-class{color:blue;font-size:30px;}</style>');
+    });
 
     it.todo('should transform template string literal with obj import');
 

--- a/src/ts-transformer/css-prop/visitors/visit-jsx-element-with-css-prop.tsx
+++ b/src/ts-transformer/css-prop/visitors/visit-jsx-element-with-css-prop.tsx
@@ -38,7 +38,8 @@ export const visitJsxElementWithCssProp = (
     // string literal found with substitutions e.g. css={`color: ${color}`}
     const processed = templateLiteralToCss(
       cssJsxAttribute.initializer.expression,
-      variableDeclarations
+      variableDeclarations,
+      context
     );
     cssVariables = processed.cssVariables;
     cssToPassThroughCompiler = processed.css;

--- a/src/ts-transformer/utils/template-literal-to-css.tsx
+++ b/src/ts-transformer/utils/template-literal-to-css.tsx
@@ -2,12 +2,14 @@ import * as ts from 'typescript';
 import { ToCssReturnType, CssVariableExpressions, VariableDeclarations } from '../types';
 import { getIdentifierText } from './ast-node';
 import { nextCssVariableName } from './identifiers';
+import { objectLiteralToCssString } from './object-literal-to-css';
 
 export const templateLiteralToCss = (
   node: ts.TemplateExpression,
-  scopedVariables: VariableDeclarations
+  scopedVariables: VariableDeclarations,
+  context: ts.TransformationContext
 ): ToCssReturnType => {
-  const cssVariables: CssVariableExpressions[] = [];
+  let cssVariables: CssVariableExpressions[] = [];
   let css = '';
 
   css = node.head.text;
@@ -20,17 +22,21 @@ export const templateLiteralToCss = (
       throw new Error('variable doesnt exist in scope');
     }
 
-    if (!ts.isStringLiteral(value.initializer)) {
+    if (ts.isObjectLiteralExpression(value.initializer)) {
+      const processed = objectLiteralToCssString(value.initializer, scopedVariables, context);
+      css = processed.css;
+      cssVariables = cssVariables.concat(processed.cssVariables);
+    } else if (!ts.isStringLiteral(value.initializer)) {
       throw new Error('only string literals supported atm');
+    } else {
+      const cssVariableReference = `var(${variableName})`;
+      cssVariables.push({
+        name: variableName,
+        identifier: span.expression as ts.Identifier,
+      });
+
+      css += `${cssVariableReference}${span.literal.text}`;
     }
-
-    const cssVariableReference = `var(${variableName})`;
-    cssVariables.push({
-      name: variableName,
-      identifier: span.expression as ts.Identifier,
-    });
-
-    css += `${cssVariableReference}${span.literal.text}`;
   });
 
   return {


### PR DESCRIPTION
This adds support for transforming a template string literal that contains an object of style values